### PR TITLE
docs: fix typos

### DIFF
--- a/docs/auth-service/workflow.md
+++ b/docs/auth-service/workflow.md
@@ -47,4 +47,4 @@ After user redirected to the dApp callback URL, dApp needs to verify the signatu
 3. `state` (string, required): State string passed from dApp.
 4. `subkey` (string, required): Subkey public key hex string.
 5. `subkey_cert_sig` (string, required): Subkey certification signature signed by Avatar, encoded in Base58.
-6. `sig` (string, required): Signature of `avatar=${avatar}\nredirect_uri={redirect_uri}\nexpired_at=${expired_at}\nstate=${state}` singed by Subkey, encoded in Base58.
+6. `sig` (string, required): Signature of `avatar=${avatar}\nredirect_uri={redirect_uri}\nexpired_at=${expired_at}\nstate=${state}` signed by Subkey, encoded in Base58.

--- a/docs/relation-service/system.md
+++ b/docs/relation-service/system.md
@@ -26,7 +26,7 @@ When performing a data fetching process, RelationService will
 2. Request and collect results from each upstream available
 3. Newly fetched data will be fed into this circulation again, until no new data is yield.
 
-A psuedo code snippet describing this:
+A pseudo code snippet describing this:
 
 ```ruby
 up_next = [{platform: :platform_to_query, identity: "identity_to_query"}]

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/auth-service/workflow.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/auth-service/workflow.md
@@ -47,4 +47,4 @@ After user redirected to the dApp callback URL, dApp needs to verify the signatu
 3. `state` (string, required): State string passed from dApp.
 4. `subkey` (string, required): Subkey public key hex string.
 5. `subkey_cert_sig` (string, required): Subkey certification signature signed by Avatar, encoded in Base58.
-6. `sig` (string, required): Signature of `avatar=${avatar}\nredirect_uri={redirect_uri}\nexpired_at=${expired_at}\nstate=${state}` singed by Subkey, encoded in Base58.
+6. `sig` (string, required): Signature of `avatar=${avatar}\nredirect_uri={redirect_uri}\nexpired_at=${expired_at}\nstate=${state}` signed by Subkey, encoded in Base58.


### PR DESCRIPTION
Hey :wave:,

This PR will fix :

1 typo in `docs/auth-service/workflow.md`
1 typo in `docs/relation-service/system.md`
1 typo in `i18n/zh-Hans/docusaurus-plugin-content-docs/current/auth-service/workflow.md`


Best!